### PR TITLE
Reduce logging

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -186,7 +186,7 @@ export class AirthingsPlugin implements AccessoryPlugin {
 
     try {
       this.latestSamples = await this.airthingsApi.getLatestSamples(this.airthingsConfig.serialNumber);
-      this.log.info(JSON.stringify(this.latestSamples.data));
+      this.log.debug(JSON.stringify(this.latestSamples.data));
     }
     catch (err) {
       if (err instanceof Error) {


### PR DESCRIPTION
Change the latest samples log message to use `log.debug` to reduce the amount of messages in the main HomeBridge log file to a manageable level.