### PR TITLE
Add support for Wave Enhance

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -105,7 +105,22 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
                     voc: false
                 }
             } as AirthingsDeviceInfo;
-        default:
+        case '3220':
+            return {
+                model: "Wave Enhance",
+                sensors: {
+                    co2: true,
+                    humidity: true,
+                    mold: false,
+                    pm1: false,
+                    pm25: false,
+                    pressure: true,
+                    radonShortTermAvg: false,
+                    temp: true,
+                    voc: true
+                }
+            } as AirthingsDeviceInfo;
+         default:
             return {
                 model: 'Unknown',
                 sensors: {


### PR DESCRIPTION
This adds support for the air quality sensors of the Wave Enhance.  It does not add support for noise or light sensors which would require more significant changes.

This resolves #45 for the most part.