### PR TITLE
Add support for Corentium Home 2 and Renew

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A [Homebridge](https://homebridge.io) plugin for [Airthings](https://www.airthin
 
 | Airthings Device                                                     | Serial Number |
 | -------------------------------------------------------------------- | ------------- |
+| [Airthings Corentium Home 2](https://www.airthings.com/corentium-home-2) | 3250xxxxxx    |
+| [Airthings Renew](https://www.airthings.com/renew)                   | 4100xxxxxx    |
 | [Airthings View Plus](https://www.airthings.com/view-plus)           | 2960xxxxxx    |
 | [Airthings View Radon](https://www.airthings.com/view-radon)         | 2989xxxxxx    |
 | [Airthings Wave Enhance](https://www.airthings.com/wave-enhance)     | 3210xxxxxx    |

--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ A [Homebridge](https://homebridge.io) plugin for [Airthings](https://www.airthin
 
 ### Supported Devices
 
-| Airthings Device                                                     | Serial Number |
-| -------------------------------------------------------------------- | ------------- |
+| Airthings Device                                                         | Serial Number |
+| ------------------------------------------------------------------------ | ------------- |
 | [Airthings Corentium Home 2](https://www.airthings.com/corentium-home-2) | 3250xxxxxx    |
-| [Airthings Renew](https://www.airthings.com/renew)                   | 4100xxxxxx    |
-| [Airthings View Plus](https://www.airthings.com/view-plus)           | 2960xxxxxx    |
-| [Airthings View Radon](https://www.airthings.com/view-radon)         | 2989xxxxxx    |
-| [Airthings Wave Enhance](https://www.airthings.com/wave-enhance)     | 3210xxxxxx    |
-| [Airthings Wave Enhance](https://www.airthings.com/wave-enhance)     | 3220xxxxxx    |
-| [Airthings Wave Plus](https://www.airthings.com/wave-plus)           | 2930xxxxxx    |
-| [Airthings Wave Radon](https://www.airthings.com/wave-radon)         | 2950xxxxxx    |
-| [Airthings Wave Mini](https://www.airthings.com/wave-mini)           | 2920xxxxxx    |
+| [Airthings Renew](https://www.airthings.com/renew)                       | 4100xxxxxx    |
+| [Airthings View Plus](https://www.airthings.com/view-plus)               | 2960xxxxxx    |
+| [Airthings View Radon](https://www.airthings.com/view-radon)             | 2989xxxxxx    |
+| [Airthings Wave Enhance](https://www.airthings.com/wave-enhance)         | 3210xxxxxx    |
+| [Airthings Wave Enhance](https://www.airthings.com/wave-enhance)         | 3220xxxxxx    |
+| [Airthings Wave Plus](https://www.airthings.com/wave-plus)               | 2930xxxxxx    |
+| [Airthings Wave Radon](https://www.airthings.com/wave-radon)             | 2950xxxxxx    |
+| [Airthings Wave Mini](https://www.airthings.com/wave-mini)               | 2920xxxxxx    |
 
 Note: Airthings Wave devices require an Airthings SmartLink Hub ([View Plus](https://www.airthings.com/view-plus), [View Radon](https://www.airthings.com/view-radon)) to continuously push measurement data to the Airthings Cloud.
 

--- a/src/device.ts
+++ b/src/device.ts
@@ -4,6 +4,7 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
             return {
                 model: 'Wave',
                 sensors: {
+                    battery: true,
                     co2: false,
                     humidity: true,
                     mold: false,
@@ -19,6 +20,7 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
             return {
                 model: 'Wave Mini',
                 sensors: {
+                    battery: true,
                     co2: false,
                     humidity: true,
                     mold: true,
@@ -34,6 +36,7 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
             return {
                 model: 'Wave Plus',
                 sensors: {
+                    battery: true,
                     co2: true,
                     humidity: true,
                     mold: false,
@@ -49,6 +52,7 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
             return {
                 model: 'Wave Radon',
                 sensors: {
+                    battery: true,
                     co2: false,
                     humidity: true,
                     mold: false,
@@ -64,6 +68,7 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
             return {
                 model: 'View Plus',
                 sensors: {
+                    battery: true,
                     co2: true,
                     humidity: true,
                     mold: false,
@@ -79,6 +84,7 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
             return {
                 model: 'View Pollution',
                 sensors: {
+                    battery: true,
                     co2: false,
                     humidity: true,
                     mold: false,
@@ -94,6 +100,7 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
             return {
                 model: 'View Radon',
                 sensors: {
+                    battery: true,
                     co2: false,
                     humidity: true,
                     mold: false,
@@ -110,6 +117,7 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
             return {
                 model: 'Wave Enhance',
                 sensors: {
+                    battery: true,
                     co2: true,
                     humidity: true,
                     mold: false,
@@ -125,6 +133,7 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
             return {
                 model: 'Corentium Home 2',
                 sensors: {
+                    battery: true,
                     co2: false,
                     humidity: true,
                     mold: false,
@@ -140,6 +149,7 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
             return {
                 model: 'Renew',
                 sensors: {
+                    battery: false,
                     co2: false,
                     humidity: false,
                     mold: false,
@@ -155,6 +165,7 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
             return {
                 model: 'Unknown',
                 sensors: {
+                    battery: false,
                     co2: false,
                     humidity: false,
                     mold: false,
@@ -172,6 +183,7 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
 export interface AirthingsDeviceInfo {
     model: string;
     sensors: {
+        battery: boolean;
         co2: boolean;
         humidity: boolean;
         mold: boolean;

--- a/src/device.ts
+++ b/src/device.ts
@@ -121,6 +121,36 @@ export function getAirthingsDeviceInfoBySerialNumber(serialNumber: string) {
                     voc: true
                 }
             } as AirthingsDeviceInfo;
+        case '3250':
+            return {
+                model: 'Corentium Home 2',
+                sensors: {
+                    co2: false,
+                    humidity: true,
+                    mold: false,
+                    pm1: false,
+                    pm25: false,
+                    pressure: false,
+                    radonShortTermAvg: true,
+                    temp: true,
+                    voc: false
+                }
+            } as AirthingsDeviceInfo;
+        case '4100':
+            return {
+                model: 'Renew',
+                sensors: {
+                    co2: false,
+                    humidity: false,
+                    mold: false,
+                    pm1: false,
+                    pm25: true,
+                    pressure: false,
+                    radonShortTermAvg: false,
+                    temp: false,
+                    voc: false
+                }
+            } as AirthingsDeviceInfo;
         default:
             return {
                 model: 'Unknown',

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -183,7 +183,7 @@ export class AirthingsPlugin implements AccessoryPlugin {
     getServices(): Service[] {
         const services = [this.informationService, this.airQualityService];
 
-        if (!this.airthingsConfig.batteryDisabled) {
+        if (this.airthingsDevice.sensors.battery && !this.airthingsConfig.batteryDisabled) {
             services.push(this.batteryService);
         }
 


### PR DESCRIPTION
Renew doesn't have batteries, so added a `battery` config as well.