### PR TITLE
Prefix service names with the accessory name

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -102,10 +102,10 @@ export class AirthingsPlugin implements AccessoryPlugin {
             .setCharacteristic(api.hap.Characteristic.FirmwareRevision, 'Unknown');
 
         // HomeKit Battery Service
-        this.batteryService = new api.hap.Service.Battery('Battery');
+        this.batteryService = new api.hap.Service.Battery(`${config.name} Battery`);
 
         // HomeKit Air Quality Service
-        this.airQualityService = new api.hap.Service.AirQualitySensor('Air Quality');
+        this.airQualityService = new api.hap.Service.AirQualitySensor(`${config.name} Air Quality`);
 
         if (this.airthingsDevice.sensors.co2 && !this.airthingsConfig.co2AirQualityDisabled) {
             this.airQualityService.getCharacteristic(api.hap.Characteristic.CarbonDioxideLevel).setProps({});
@@ -149,16 +149,16 @@ export class AirthingsPlugin implements AccessoryPlugin {
         }
 
         // HomeKit Temperature Service
-        this.temperatureService = new api.hap.Service.TemperatureSensor('Temp');
+        this.temperatureService = new api.hap.Service.TemperatureSensor(`${config.name} Temp`);
 
         // HomeKit Humidity Service
-        this.humidityService = new api.hap.Service.HumiditySensor('Humidity');
+        this.humidityService = new api.hap.Service.HumiditySensor(`${config.name} Humidity`);
 
         // HomeKit CO2 Service
-        this.carbonDioxideService = new api.hap.Service.CarbonDioxideSensor('CO2');
+        this.carbonDioxideService = new api.hap.Service.CarbonDioxideSensor(`${config.name} CO2`);
 
         // Eve Air Pressure Service
-        this.airPressureService = new api.hap.Service('Air Pressure', 'e863f00a-079e-48ff-8f27-9c2605a29f52');
+        this.airPressureService = new api.hap.Service(`${config.name} Air Pressure`, 'e863f00a-079e-48ff-8f27-9c2605a29f52');
 
         this.airPressureService.addCharacteristic(new api.hap.Characteristic('Air Pressure', 'e863f10f-079e-48ff-8f27-9c2605a29f52', {
             format: Formats.UINT16,
@@ -172,7 +172,7 @@ export class AirthingsPlugin implements AccessoryPlugin {
         this.airPressureService.addCharacteristic(api.hap.Characteristic.StatusActive);
 
         // HomeKit Radon (Leak) Service
-        this.radonService = new api.hap.Service.LeakSensor('Radon');
+        this.radonService = new api.hap.Service.LeakSensor(`${config.name} Radon`);
 
         this.refreshCharacteristics(api);
         setInterval(async () => {


### PR DESCRIPTION
### Problem

Every service this plugin creates is named with a hardcoded literal — `'Temp'`, `'Humidity'`, `'Battery'`, `'Air Quality'`, `'CO2'`, `'Air Pressure'`, `'Radon'` — so two Airthings devices on the same bridge publish services with identical names.

That makes them indistinguishable in Homebridge UI. `@homebridge/hap-client` derives each service's `nameBasedUniqueId` as:

```js
sha256([
  service.instance.name,                      // "homebridge"
  service.instance.username,                  // bridge MAC
  service.accessoryInformation.Manufacturer,  // "Airthings"
  service.serviceName,                        // "Temp"
  service.uuid.slice(0, 8),                   // service type
].join('|'))
```

The serial number isn't an input. With two Airthings devices on one bridge, all five components match, so both devices' services hash to the same value. Homebridge UI keys custom names on that hash, with two visible consequences:

- Renaming one device's tile silently renames the other's.
- The two services collapse into a single tile, so one device's sensors go missing from the room they were placed in.

All seven services collide. I hit this with a View Plus and a Wave Radon on one bridge — every rename applied to both devices, which looked like the UI was failing to save.

### Fix

Prefix each service name with `config.name`, which is already used for the accessory's `Name` characteristic (line 100) and is therefore in scope and guaranteed set (the plugin defaults it upstream).

### Verification

Computing `nameBasedUniqueId` for both of my devices, before and after:

| Service | Before | After |
|---|---|---|
| Battery | ❌ collides | ✅ `c5583c8a…` vs `636dfcea…` |
| Air Quality | ❌ collides | ✅ `19f83c0b…` vs `7c5b7ce1…` |
| Temp | ❌ collides | ✅ `763dc51f…` vs `eef5d29e…` |
| Humidity | ❌ collides | ✅ `c36e58e0…` vs `61324296…` |
| CO2 | ❌ collides | ✅ `cb7e57d4…` vs `02aefa4e…` |
| Air Pressure | ❌ collides | ✅ `74aae75b…` vs `5b1c6400…` |
| Radon | ❌ collides | ✅ `e88488f2…` vs `bf0604dc…` |

7/7 collide before, 0/7 after. `npm run build` (lint + tsc) passes clean.

### Compatibility

`uniqueId` hashes `username + aid + iid + type`, none of which change here, so existing Homebridge UI room layouts and HomeKit pairings are preserved. This is not a bridge-identity change.

The user-visible effect is that service names in the Home app become e.g. "Blue Room View Plus Temp" instead of "Temp". Names users have set themselves in the Home app take precedence and are unaffected. If you'd rather not change this for existing single-device users, I'm happy to put it behind a config flag or apply the prefix only when more than one accessory is configured — just say which you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPgfBrVBq5w5useKSLXR14
